### PR TITLE
Add TextChunkingProcessor event and info stats

### DIFF
--- a/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
+++ b/src/main/java/org/opensearch/neuralsearch/processor/TextChunkingProcessor.java
@@ -24,6 +24,7 @@ import org.opensearch.neuralsearch.processor.chunker.Chunker;
 import org.opensearch.index.mapper.IndexFieldMapper;
 import org.opensearch.neuralsearch.processor.chunker.ChunkerFactory;
 import org.opensearch.neuralsearch.processor.chunker.FixedTokenLengthChunker;
+import org.opensearch.neuralsearch.stats.EventStatsManager;
 import org.opensearch.neuralsearch.util.ProcessorDocumentUtils;
 
 import static org.opensearch.neuralsearch.processor.chunker.Chunker.MAX_CHUNK_LIMIT_FIELD;
@@ -192,6 +193,7 @@ public final class TextChunkingProcessor extends AbstractProcessor {
         runtimeParameters.put(MAX_CHUNK_LIMIT_FIELD, maxChunkLimit);
         runtimeParameters.put(CHUNK_STRING_COUNT_FIELD, chunkStringCount);
         chunkMapType(sourceAndMetadataMap, fieldMap, runtimeParameters);
+        EventStatsManager.recordTextChunkingExecution(chunker.getAlgorithmName());
         return ingestDocument;
     }
 

--- a/src/main/java/org/opensearch/neuralsearch/stats/EventStatsManager.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/EventStatsManager.java
@@ -4,6 +4,8 @@
  */
 package org.opensearch.neuralsearch.stats;
 
+import org.opensearch.neuralsearch.processor.chunker.DelimiterChunker;
+import org.opensearch.neuralsearch.processor.chunker.FixedTokenLengthChunker;
 import org.opensearch.neuralsearch.stats.names.EventStatName;
 import org.opensearch.neuralsearch.stats.names.StatType;
 import org.opensearch.neuralsearch.stats.suppliers.CounterSupplier;
@@ -25,8 +27,6 @@ public class EventStatsManager {
     }
 
     private static void increment(EventStatName eventStatName) {
-        // Should write helper methods to wrap this increment call
-        // Business logic should call wrapped methods, never increment directly
         instance().getStats().computeIfAbsent(eventStatName.getName(), k -> new NeuralStat<>(new CounterSupplier())).increment();
     }
 
@@ -57,6 +57,18 @@ public class EventStatsManager {
             if (eventStatName.getStatType() == StatType.EVENT_COUNTER) {
                 eventStatsMap.computeIfAbsent(eventStatName.getName(), k -> new NeuralStat<>(new CounterSupplier()));
             }
+        }
+    }
+
+    public static void recordTextChunkingExecution(String algorithm) {
+        increment(EventStatName.TEXT_CHUNKING_PROCESSOR_EXECUTIONS);
+        switch (algorithm) {
+            case DelimiterChunker.ALGORITHM_NAME:
+                increment(EventStatName.TEXT_CHUNKING_ALGORITHM_DELIMITER_EXECUTIONS);
+                break;
+            case FixedTokenLengthChunker.ALGORITHM_NAME:
+                increment(EventStatName.TEXT_CHUNKING_ALGORITHM_FIXED_LENGTH_EXECUTIONS);
+                break;
         }
     }
 }

--- a/src/main/java/org/opensearch/neuralsearch/stats/names/DerivedStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/names/DerivedStatName.java
@@ -12,7 +12,30 @@ import java.util.Set;
 @Getter
 public enum DerivedStatName {
     // Cluster info
-    CLUSTER_VERSION("cluster_version", StatType.DERIVED_INFO_COUNTER);
+    CLUSTER_VERSION("cluster_version", StatType.DERIVED_INFO_COUNTER),
+
+    // Search processor info
+
+    // Ingest processor info
+    INGEST_TEXT_CHUNKING_PROCESSOR_COUNT("pipelines.ingest.processors.text_chunking.count", StatType.DERIVED_INFO_COUNTER),
+    INGEST_TEXT_CHUNKING_ALGORITHM_FIXED_LENGTH(
+        "pipelines.ingest.processors.text_chunking.algorithm.fixed_length",
+        StatType.DERIVED_INFO_COUNTER
+    ),
+    INGEST_TEXT_CHUNKING_ALGORITHM_DELIMITER(
+        "pipelines.ingest.processors.text_chunking.algorithm.delimiter",
+        StatType.DERIVED_INFO_COUNTER
+    ),
+    INGEST_TEXT_CHUNKING_TOKENIZER_STANDARD("pipelines.ingest.processors.text_chunking.tokenizer.standard", StatType.DERIVED_INFO_COUNTER),
+    INGEST_TEXT_CHUNKING_TOKENIZER_LETTER("pipelines.ingest.processors.text_chunking.tokenizer.letter", StatType.DERIVED_INFO_COUNTER),
+    INGEST_TEXT_CHUNKING_TOKENIZER_LOWERCASE(
+        "pipelines.ingest.processors.text_chunking.tokenizer.lowercase",
+        StatType.DERIVED_INFO_COUNTER
+    ),
+    INGEST_TEXT_CHUNKING_TOKENIZER_WHITESPACE(
+        "pipelines.ingest.processors.text_chunking.tokenizer.whitespace",
+        StatType.DERIVED_INFO_COUNTER
+    );
 
     private final String name;
     private final StatType statType;

--- a/src/main/java/org/opensearch/neuralsearch/stats/names/EventStatName.java
+++ b/src/main/java/org/opensearch/neuralsearch/stats/names/EventStatName.java
@@ -13,7 +13,9 @@ import java.util.Set;
 public enum EventStatName {
     // Search processor events
     // Ingest processor events
-    ;
+    TEXT_CHUNKING_PROCESSOR_EXECUTIONS("ingest_processor.text_chunking.executions", StatType.EVENT_COUNTER),
+    TEXT_CHUNKING_ALGORITHM_FIXED_LENGTH_EXECUTIONS("ingest_processor.text_chunking.algorithm.fixed_length", StatType.EVENT_COUNTER),
+    TEXT_CHUNKING_ALGORITHM_DELIMITER_EXECUTIONS("ingest_processor.text_chunking.algorithm.delimiter", StatType.EVENT_COUNTER),;
 
     private final String name;
     private final StatType statType;


### PR DESCRIPTION
### Description
Example PR to showcase adding a stats for TextChunkingProcessor

Event stats:
 - Total processor execution count
 - Delimiter algorithm execution count
 - Fixed length algorithm execution count

Info stats:
 - Number of processors in pipelines
 - Number of processors by algorithm in pipelines
 - Number of fixed length algorithm processors by tokenizer (standard, lowercase, whitespace, letter) in pipelines

Example response:

```
{
	"_nodes": {
		"total": 1,
		"successful": 1,
		"failed": 0
	},
	"cluster_name": "integTest",
	"all_nodes": {
		"ingest_processor": {
			"text_chunking": {
				"executions": 0,
				"algorithm": {
					"fixed_length": 0,
					"delimiter": 0
				}
			}
		}
	},
	"cluster_version": "3.0.0",
	"pipelines": {
		"ingest": {
			"processors": {
				"text_chunking": {
					"count": 0,
					"tokenizer": {
						"standard": 0,
						"lowercase": 0,
						"letter": 0,
						"whitespace": 0
					},
					"algorithm": {
						"fixed_length": 0,
						"delimiter": 0
					}
				}
			}
		}
	}
}
```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/neural-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
